### PR TITLE
Change tags for insensitive, cleanup already existent tags/tagged items

### DIFF
--- a/core/migrations/0005_auto_20161004_1431.py
+++ b/core/migrations/0005_auto_20161004_1431.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def cleanup_tags(apps, schema_editor):
+    Tag = apps.get_model("taggit", "Tag")
+    PageTag = apps.get_model("core", "PageTag")
+    tags_processed = []
+    duplicated_tags_id = []
+    for tag in Tag.objects.all():
+        if tag.name.lower() not in tags_processed:
+
+            tags_iexact = Tag.objects.filter(name__iexact=tag.name).order_by("id")
+            first_tag = tags_iexact.first()
+            tags_processed.append(tag.name.lower())
+
+            for duplicated_tag in tags_iexact:
+                if duplicated_tag != first_tag:
+
+                    for page_tag in PageTag.objects.filter(tag=duplicated_tag):
+                        pt_objects = PageTag.objects
+                        if not pt_objects.filter(tag=first_tag, content_object=page_tag.content_object).exists():
+                            PageTag.objects.create(tag=first_tag, content_object=page_tag.content_object)
+                        pt_objects.filter(tag=duplicated_tag, content_object=page_tag.content_object).delete()
+                    duplicated_tags_id.append(duplicated_tag.id)
+    Tag.objects.filter(id__in=duplicated_tags_id).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0004_auto_20160511_1652'),
+    ]
+
+    operations = [
+        migrations.RunPython(cleanup_tags, migrations.RunPython.noop),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -87,7 +87,7 @@ class HomePage(Page, IndexPage):
         # Filter by tag
         tag = request.GET.get('tag')
         if tag:
-            pages = pages.filter(tags__name=tag)
+            pages = pages.filter(tags__name__iexact=tag)
 
         # Pagination
         page = request.GET.get('page')
@@ -142,7 +142,7 @@ class CompanyIndex(Page, IndexPage):
         # Filter by tag
         tag = request.GET.get('tag')
         if tag:
-            pages = pages.filter(tags__name=tag)
+            pages = pages.filter(tags__name__iexact=tag)
 
         # Pagination
         page = request.GET.get('page')

--- a/madewithwagtail/settings/base.py
+++ b/madewithwagtail/settings/base.py
@@ -197,6 +197,8 @@ LOGIN_REDIRECT_URL = 'wagtailadmin_home'
 WAGTAIL_ADDRESS_MAP_CENTER = 'Wellington, New Zealand'
 WAGTAIL_ADDRESS_MAP_ZOOM = 8
 
+TAGGIT_CASE_INSENSITIVE = True
+
 # REST framework
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Fixes #40 

I had to create a cleanup migration.
- If a Page has 2 tags with the same lower name, it will preserve only the tag with smaller id. 
- If a Page has a tag which has a tag with the same lower name and the tag for the page isn't the one with smaller id, it will delete the relation and create a new one with the tag-smaller-id
- Preserve only tags with the smaller ids.