### PR TITLE
Add multiple hooks and first publish check to Slack integration

### DIFF
--- a/core/signals.py
+++ b/core/signals.py
@@ -85,21 +85,22 @@ def post_model_save(sender, instance, **kwargs):
 
 @receiver(page_published, sender=WagtailSitePage)
 def send_to_slack(sender, **kwargs):
-    url = getattr(settings, 'PUBLISH_SLACK_HOOK', None)
-    if not url:
+    hooks = getattr(settings, 'PUBLISH_SLACK_HOOKS', [])
+    if not hooks:
         return
 
     page = kwargs['instance']
-    Slack(url).send({
-        'text': 'New site published! :rocket:',
-        'username': 'Made with Wagtail',
-        'icon_emoji': ':bird:',
-        'attachments': [
-            {
-                'fallback': '%s - %s' % (page.title, page.site_url),
-                'title': page.title,
-                'text': page.full_url,
-                'color': '#43b1b0',
-            }
-        ]
-    })
+    for hook in hooks:
+        Slack(hook).send({
+            'text': 'New site published! :rocket:',
+            'username': 'Made with Wagtail',
+            'icon_emoji': ':bird:',
+            'attachments': [
+                {
+                    'fallback': '%s - %s' % (page.title, page.site_url),
+                    'title': page.title,
+                    'text': page.full_url,
+                    'color': '#43b1b0',
+                }
+            ]
+        })

--- a/madewithwagtail/settings/base.py
+++ b/madewithwagtail/settings/base.py
@@ -197,6 +197,10 @@ LOGIN_REDIRECT_URL = 'wagtailadmin_home'
 WAGTAIL_ADDRESS_MAP_CENTER = 'Wellington, New Zealand'
 WAGTAIL_ADDRESS_MAP_ZOOM = 8
 
+# List of web hook URLs we push Slack messages to on page publish.
+# URLs should stay secret - define them in local.py
+PUBLISH_SLACK_HOOKS = []
+
 TAGGIT_CASE_INSENSITIVE = True
 
 # REST framework

--- a/madewithwagtail/settings/local.py.example
+++ b/madewithwagtail/settings/local.py.example
@@ -7,8 +7,10 @@ RECAPTCHA_PUBLIC_KEY = 'set_your_key'
 RECAPTCHA_PRIVATE_KEY = 'set_your_key'
 NOCAPTCHA = True
 
-# Web hook URL for page publication.
-PUBLISH_SLACK_HOOK = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+# List of web hook URLs we push Slack messages to on page publish.
+PUBLISH_SLACK_HOOKS = [
+    'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+]
 
 # Google Analytics settings
 GOOGLE_ANALYTICS_KEY = False


### PR DESCRIPTION
Fix #69 – adds a check so hooks are fired only on the first publish.

Also add the ability to have multiple Slack hooks (so we can notify both the Springload Slack and Wagtail's). This requires changes in `local.py` so I will leave deployment with you @loicteixeira.

