### PR TITLE
Makes site URL optional.

### DIFF
--- a/core/migrations/0007_auto_20170503_2308.py
+++ b/core/migrations/0007_auto_20170503_2308.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import wagtail.wagtailcore.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0006_wagtail_1_6_upgrade'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='companyindex',
+            name='show_map',
+            field=models.BooleanField(default=False, help_text='Show map of companies around the world.'),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='css_class',
+            field=models.CharField(blank=True, verbose_name='CSS Class', help_text='Optional styling for the menu item', max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='explicit_name',
+            field=models.CharField(blank=True, help_text='If you want a different name than the page title.', max_length=64, null=True),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='icon_class',
+            field=models.CharField(blank=True, verbose_name='Icon Class', help_text='In case you need an icon element <i> for the menu item', max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='link_document',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, related_name='+', blank=True, help_text='Choose an existing document if you want the link to open a document.', to='wagtaildocs.Document', null=True),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='link_email',
+            field=models.EmailField(blank=True, help_text='Set the recipient email address if you want the link to send an email.', max_length=254, null=True),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='link_external',
+            field=models.URLField(blank=True, verbose_name='External link', help_text='Set an external link if you want the link to point somewhere outside the CMS.', null=True),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='link_page',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, related_name='+', blank=True, help_text='Choose an existing page if you want the link to point somewhere inside the CMS.', to='wagtailcore.Page', null=True),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='link_phone',
+            field=models.CharField(blank=True, help_text='Set the number if you want the link to dial a phone number.', max_length=20, null=True),
+        ),
+        migrations.AlterField(
+            model_name='menuelement',
+            name='short_name',
+            field=models.CharField(blank=True, help_text='If you need a custom name for responsive devices.', max_length=32, null=True),
+        ),
+        migrations.AlterField(
+            model_name='submitformpage',
+            name='body',
+            field=wagtail.wagtailcore.fields.RichTextField(blank=True, help_text='Edit the content you want to see before the form.'),
+        ),
+        migrations.AlterField(
+            model_name='submitformpage',
+            name='thank_you_text',
+            field=wagtail.wagtailcore.fields.RichTextField(blank=True, help_text='Set the message users will see after submitting the form.'),
+        ),
+        migrations.AlterField(
+            model_name='wagtailcompanypage',
+            name='company_url',
+            field=models.URLField(blank=True, help_text='Paste the URL of your site, something like "https://www.springload.co.nz"', null=True),
+        ),
+        migrations.AlterField(
+            model_name='wagtailcompanypage',
+            name='show_map',
+            field=models.BooleanField(default=True, help_text='Show company in the map of companies around the world.'),
+        ),
+        migrations.AlterField(
+            model_name='wagtailsitepage',
+            name='is_featured',
+            field=models.BooleanField(default=False, help_text='If enabled, this site will appear on top of the sites list of the homepage.', verbose_name='Featured'),
+        ),
+        migrations.AlterField(
+            model_name='wagtailsitepage',
+            name='site_url',
+            field=models.URLField(blank=True, help_text='Paste the URL of your site, something like "http://www.springload.co.nz"', null=True),
+        ),
+    ]

--- a/core/models.py
+++ b/core/models.py
@@ -375,7 +375,7 @@ class WagtailSitePage(WagtailPage):
         related_name='+'
     )
     site_url = models.URLField(
-        blank=False,
+        blank=True,
         null=True,
         help_text='Paste the URL of your site, something like "http://www.springload.co.nz"',
     )
@@ -398,6 +398,8 @@ class WagtailSitePage(WagtailPage):
         return image
 
     def __unicode__(self):
+        if self.site_url:
+            return '%s - %s' % (self.title, self.site_url)
         return self.title
 
     class Meta:

--- a/core/signals.py
+++ b/core/signals.py
@@ -5,6 +5,7 @@ from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.core.cache import cache
 from django.conf import settings
+from django.utils.encoding import force_text
 
 from slackweb import Slack
 
@@ -104,7 +105,7 @@ def send_to_slack(sender, **kwargs):
                 'icon_emoji': ':bird:',
                 'attachments': [
                     {
-                        'fallback': '%s - %s' % (page.title, page.site_url),
+                        'fallback': force_text(page),
                         'title': page.title,
                         'text': page.full_url,
                         'color': '#43b1b0',

--- a/core/templates/core/includes/sites.html
+++ b/core/templates/core/includes/sites.html
@@ -17,10 +17,12 @@
                         <span class="u-sr-only">Project info</span>
                         {% include "core/includes/icon.html" with icon="info" color="grey" class="i--hover" %}
                     </a>
-                    <a class="project__visit" href="{{ page.site_url }}" title="Project link" data-analytics="Project|Link click">
-                        <span class="u-sr-only">Project link</span>
-                        {% include "core/includes/icon.html" with icon="visit" color="grey" class="i--hover" %}
-                    </a>
+                    {% if page.site_url %}
+                        <a class="project__visit" href="{{ page.site_url }}" title="Project link" data-analytics="Project|Link click">
+                            <span class="u-sr-only">Project link</span>
+                            {% include "core/includes/icon.html" with icon="visit" color="grey" class="i--hover" %}
+                        </a>
+                    {% endif %}
                 </div>
             </div>
             <h4 class="project-title">

--- a/core/templates/core/wagtail_site_page.html
+++ b/core/templates/core/wagtail_site_page.html
@@ -28,10 +28,12 @@
                     </p>
                     {{ self.body|richtext }}
 
-                    <a href="{{ self.site_url }}" title="{{ self.title}}" class="btn -small icon-text" data-analytics="Project|Link click">
-                        {% include "core/includes/icon.html" with icon="visit" color="white" class="i--small u-middle" %}
-                        <span>Visit site</span>
-                    </a>
+                    {% if self.site_url %}
+                        <a href="{{ self.site_url }}" title="{{ self.title }}" class="btn -small icon-text" data-analytics="Project|Link click">
+                            {% include "core/includes/icon.html" with icon="visit" color="white" class="i--small u-middle" %}
+                            <span>Visit site</span>
+                        </a>
+                    {% endif %}
 
                     <hr>
 


### PR DESCRIPTION
Currently, we must set a URL on a each site. There are some cases where sites are no longer on any existing URLs, so I think it’s better to make this field optional.

Here are cases I met:
- a website created for an event, so it’s no longer on the web;
- a very nice website with lots of unique features that was removed from the web and replaced by a random Wordpress for political reasons, a few months after being published.