### PR TITLE
Ability to re-arrange sites within a Developer profile

### DIFF
--- a/core/migrations/0008_wagtailcompanypage_sites_ordering.py
+++ b/core/migrations/0008_wagtailcompanypage_sites_ordering.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0007_auto_20170503_2308'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='wagtailcompanypage',
+            name='sites_ordering',
+            field=models.CharField(default=b'created', max_length=20, choices=[(b'alphabetical', b'Alphabetical'), (b'created', b'Created'), (b'path', b'Path (i.e. manual)')], help_text=b'The order the sites will be listed on the page',),
+        ),
+    ]

--- a/core/panels.py
+++ b/core/panels.py
@@ -45,6 +45,10 @@ WAGTAIL_COMPANY_PAGE_CONTENT_PANELS = HOME_PAGE_CONTENT_PANELS + [
     ], heading="Coordinates")
 ]
 
+WAGTAIL_COMPANY_PAGE_SETTINGS_PANELS = Page.settings_panels + [
+    FieldPanel('sites_ordering'),
+]
+
 WAGTAIL_COMPANY_INDEX_PAGE_CONTENT_PANELS = Page.content_panels + [
     FieldPanel('show_map'),
     FieldPanel('body', classname="full"),


### PR DESCRIPTION
Close #80.

I went with a choice field instead of a boolean (as it was discussed on the issue) so we have more options.

Default is set to mimic current behaviour so there should be no visible changes unless the developer's page is updated.