### PR TITLE
Fix load_initial_data command for django>=1.11

### DIFF
--- a/core/management/commands/load_initial_data.py
+++ b/core/management/commands/load_initial_data.py
@@ -3,11 +3,11 @@ import shutil
 
 from django.conf import settings
 from django.core.management import call_command
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 
-class Command(NoArgsCommand):
-    def handle_noargs(self, **options):
+class Command(BaseCommand):
+    def handle(self, *args, **options):
         fixtures_dir = os.path.join(settings.PROJECT_ROOT, settings.SITE_NAME, 'core', 'fixtures')
         fixture_file = os.path.join(fixtures_dir, 'initial_data.json')
         image_src_dir = os.path.join(fixtures_dir, 'images')


### PR DESCRIPTION
I hit the error when doing clean vagrant up. 
`NoArgsCommand` was deprecated and removed in [django 1.10](https://docs.djangoproject.com/en/2.0/releases/1.10/#features-removed-in-1-10) in favour of BaseCommand (which takes no arguments by default)
