### PR TITLE
Fix Developers Logos Sizes

### DIFF
--- a/core/templates/core/company_index.html
+++ b/core/templates/core/company_index.html
@@ -26,7 +26,7 @@
                         <a class="company-listing  link-ghost" href="{% pageurl company %}">
                             <div class="media__image">
                                 {% if company.logo %}
-                                {% image company.logo fill-80x80-c100 as company_logo %}
+                                {% image company.logo max-80x80 as company_logo %}
                                 <img src="{{ company_logo.url }}" alt="{{ company_logo.title }}" title="{{ company_logo.title }}" />
                                 {% else %}
                                 <div class="company__placeholder"></div>

--- a/core/templates/core/wagtail_company_page.html
+++ b/core/templates/core/wagtail_company_page.html
@@ -13,7 +13,7 @@
                     {% if self.logo %}
                         <div>
                             <div class="company__logo">
-                                {% image self.logo width-500 as company_logo %}
+                                {% image self.logo max-120x120 as company_logo %}
                                 <img src="{{ company_logo.url }}" alt="{{ company_logo.title }}" title="{{ company_logo.title }}" />
                             </div>
                         </div>


### PR DESCRIPTION
- Quick fix for truncated logos on developers index page. This will need further work, see #105.
- Make logos on developers detail pages smaller (it was 4 times bigger than what its container allows it to be).