### PR TITLE
Features to vagrant provision

### DIFF
--- a/vagrant/postgres.sh
+++ b/vagrant/postgres.sh
@@ -7,3 +7,12 @@ su - vagrant -c "echo -n 'Changing postgres authorisation method ... ' && \
                              /etc/postgresql/9.3/main/pg_hba.conf && \
                  echo done! && \
                  sudo service postgresql restart"
+
+# Let us connect to the database from everywhere without credentials
+su - vagrant -c "echo -n 'Opening postgres to public ' && \
+                 sudo grep -q -F 'host	all	all	0.0.0.0/0	trust' /etc/postgresql/9.3/main/pg_hba.conf || \
+                            echo 'host	all	all	0.0.0.0/0	trust' | sudo tee -a /etc/postgresql/9.3/main/pg_hba.conf && \
+                 sudo sed -i \"s/.*#.*listen_addresses = 'localhost'/listen_addresses = '*'/g\" \
+                             /etc/postgresql/9.3/main/postgresql.conf && \
+                 echo done! && \
+                 sudo service postgresql restart"

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -19,6 +19,7 @@ su - vagrant -c "/usr/local/bin/virtualenv $VIRTUALENV_DIR && \
 # Install pip dependencies, recursively and in order
 filename="$PROJECT_DIR/$REQUIREMENTS_FILE"
 
+su - vagrant -c "$PIP install -U pip setuptools -f /home/vagrant/wheelhouse"
 su - vagrant -c "$PIP install -r $filename -f /home/vagrant/wheelhouse"
 
 # Set execute permissions on manage.py


### PR DESCRIPTION
1.  Upgrade `pip` and `setuptools` version - to add [Environment Markers](https://www.python.org/dev/peps/pep-0508/#id23) support mainly 
2. Configure postgresql to listen for all incoming connections - allows to sign in to db from host machine using mapped port 15432