### PR TITLE
lock down wanted django version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 -c constraints.txt
-Django==1.11.7
+Django==1.11.7  # rq.filter: >=1.11,<2
 wagtail==1.13.1
 
 psycopg2==2.7.3.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -3,7 +3,7 @@ beautifulsoup4==4.6.0
 configparser==3.5.0
 contextlib2==0.5.5
 decorator==4.2.1
-Django==1.11.7
+Django==1.11.7  # rq.filter: >=1.11,<2
 django-appconf==1.0.1
 django-compressor==2.2
 django-debug-toolbar==1.5


### PR DESCRIPTION
This is  a test of requires.io dependency filters. Pyup should support them two https://pyup.io/docs/bot/filter/ 
 We shall see after we merge to master. 