### PR TITLE
Upgrade Django to fix possible vulnerability

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 -c constraints.txt
-Django==1.11.13
+Django==1.11.16
 wagtail==1.13.1
 
 psycopg2==2.7.5

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -5,7 +5,7 @@ chardet==3.0.4
 configparser==3.5.0
 contextlib2==0.5.5
 decorator==4.3.0
-Django==1.11.13
+Django==1.11.16
 django-appconf==1.0.2
 django-compressor==2.2
 django-debug-toolbar==1.9.1


### PR DESCRIPTION
more info https://docs.djangoproject.com/en/1.11/releases/1.11.15/

I think Wagtail is safe, because it doesn't allow `.` character in page slugs. therefore path to a different domain (with dot) isn't going to be resolved and redirected. 