### PR TITLE
Make `menu` tag work better without a `request` in context for 500 page

### DIFF
--- a/core/templates/500.html
+++ b/core/templates/500.html
@@ -2,6 +2,7 @@
 
 {% block body_class %}template-500{% endblock %}
 
+
 {% block content %}
     <div class="site-content content-width">
         <div class="banner ">

--- a/core/templatetags/core_tags.py
+++ b/core/templatetags/core_tags.py
@@ -31,7 +31,7 @@ def menu(context, name=None, current_page=None):
 
     return {
         "links": menu_items,
-        "request": context["request"],
+        "request": context.get("request", None),
     }
 
 
@@ -50,7 +50,7 @@ def footer_menu(context, name=None, current_page=None):
 
     return {
         "links": menu_items,
-        "request": context["request"],
+        "request": context.get("request", None),
     }
 
 

--- a/madewithwagtail/urls.py
+++ b/madewithwagtail/urls.py
@@ -65,6 +65,19 @@ if settings.DEBUG:
         settings.MEDIA_URL + "images/",
         document_root=os.path.join(settings.MEDIA_ROOT, "images"),
     )
+
+    urlpatterns.append(
+        path(
+            "500/",
+            TemplateView.as_view(template_name="500.html"),
+        )
+    )
+    urlpatterns.append(
+        path(
+            "404/",
+            TemplateView.as_view(template_name="404.html"),
+        )
+    )
 else:
     from django.views.static import serve
 


### PR DESCRIPTION
The 500 page ends up burying real errors as it falls over when trying to load the menu